### PR TITLE
[fix] Add support for multiple ip address configuration

### DIFF
--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -64,7 +64,7 @@ fn main() {
     assert!(adapter.set_logging(wireguard_nt::AdapterLoggingLevel::OnWithPrefix));
 
     adapter.set_config(&interface).unwrap();
-    match adapter.set_default_route(Ipv4Net::new(internal_ip, 24).unwrap(), &interface) {
+    match adapter.set_default_route(&[Ipv4Net::new(internal_ip, 24).unwrap().into()], &interface) {
         Ok(()) => {}
         Err(err) => panic!("Failed to set default route: {}", err),
     }


### PR DESCRIPTION
Currently, the rust binding does not support multiple IP address per interface nor IPv6/IPv4 hybrid configuration.

This commit fixes this issue, but **breaks API compatibility**. I think some modification is required if this project has to keep the API compatibility in current status.