### PR TITLE
Fix last handshake time panic

### DIFF
--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use log::*;
@@ -84,7 +84,7 @@ fn main() {
             }
             let stats = adapter.get_config();
             for peer in stats.peers {
-                let handshake_age = Instant::now().duration_since(peer.last_handshake);
+                let handshake_age = SystemTime::now().duration_since(peer.last_handshake).unwrap_or_default();
                 println!(
                     "  {:?}, up: {}, down: {}, handsake: {}s ago",
                     peer.allowed_ips,
@@ -116,7 +116,7 @@ fn get_demo_server_config(pub_key: &[u8]) -> Result<(Vec<u8>, Ipv4Addr, SocketAd
         .collect();
 
     let mut s: TcpStream = TcpStream::connect_timeout(
-        addrs.get(0).expect("Failed to resolve demo server DNS"),
+        addrs.first().expect("Failed to resolve demo server DNS"),
         Duration::from_secs(5),
     )
     .expect("Failed to open connection to demo server");

--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -75,31 +75,27 @@ fn main() {
     println!("Press enter to exit");
     let done = Arc::new(AtomicBool::new(false));
     let done2 = Arc::clone(&done);
-    let thread = std::thread::spawn(move || {
-        'outer: loop {
-            let stats = adapter.get_config();
-            for peer in stats.peers {
-                let handshake_age = peer.last_handshake.map(|h| {
-                    SystemTime::now()
-                        .duration_since(h)
-                        .unwrap_or_default()
-                });
-                let handshake_msg = match handshake_age {
-                    Some(age) => format!("handshake performed {:.2}s ago", age.as_secs_f32()),
-                    None => format!("no active handshake"),
-                };
+    let thread = std::thread::spawn(move || 'outer: loop {
+        let stats = adapter.get_config();
+        for peer in stats.peers {
+            let handshake_age = peer
+                .last_handshake
+                .map(|h| SystemTime::now().duration_since(h).unwrap_or_default());
+            let handshake_msg = match handshake_age {
+                Some(age) => format!("handshake performed {:.2}s ago", age.as_secs_f32()),
+                None => format!("no active handshake"),
+            };
 
-                println!(
-                    "  {:?}, {} bytes up, {} bytes down, {handshake_msg}",
-                    peer.allowed_ips, peer.tx_bytes, peer.rx_bytes
-                );
+            println!(
+                "  {:?}, {} bytes up, {} bytes down, {handshake_msg}",
+                peer.allowed_ips, peer.tx_bytes, peer.rx_bytes
+            );
+        }
+        for _ in 0..10 {
+            if done2.load(Ordering::Relaxed) {
+                break 'outer;
             }
-            for _ in 0..10 {
-                if done2.load(Ordering::Relaxed) {
-                    break 'outer;
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
+            std::thread::sleep(Duration::from_millis(100));
         }
     });
 

--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -84,7 +84,9 @@ fn main() {
             }
             let stats = adapter.get_config();
             for peer in stats.peers {
-                let handshake_age = SystemTime::now().duration_since(peer.last_handshake).unwrap_or_default();
+                let handshake_age = SystemTime::now()
+                    .duration_since(peer.last_handshake)
+                    .unwrap_or_default();
                 println!(
                     "  {:?}, up: {}, down: {}, handsake: {}s ago",
                     peer.allowed_ips,

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -466,10 +466,7 @@ impl Adapter {
     pub fn get_luid(&self) -> u64 {
         let mut luid = 0u64;
         let ptr = &mut luid as *mut u64 as *mut wireguard_nt_raw::_NET_LUID_LH;
-        unsafe {
-            self.wireguard
-                .WireGuardGetAdapterLUID(self.adapter.0, ptr)
-        };
+        unsafe { self.wireguard.WireGuardGetAdapterLUID(self.adapter.0, ptr) };
         luid
     }
 
@@ -501,9 +498,13 @@ impl Adapter {
                 &mut size as _,
             )
         };
-        // Should never fail since we 
+        // Should never fail since we
         assert_eq!(res, 0, "Failed to query size of wireguard configuration");
-        assert_eq!(unsafe { GetLastError() }, ERROR_MORE_DATA, "WireGuardGetConfiguration returned invalid error for size request");
+        assert_eq!(
+            unsafe { GetLastError() },
+            ERROR_MORE_DATA,
+            "WireGuardGetConfiguration returned invalid error for size request"
+        );
         assert_ne!(size, 0, "Wireguard config is zero bytes"); // size has been updated
         let align = align_of::<WIREGUARD_INTERFACE>();
         let mut reader = StructReader::new(size as usize, align);
@@ -562,7 +563,8 @@ impl Adapter {
             };
             // The number of 100ns intervals between 1-1-1600 and 1-1-1970
             const UNIX_EPOCH_FROM_1_1_1600: u64 = 116444736000000000;
-            let ns_from_unix_epoch = peer.LastHandshake.saturating_sub(UNIX_EPOCH_FROM_1_1_1600) * 100;
+            let ns_from_unix_epoch =
+                peer.LastHandshake.saturating_sub(UNIX_EPOCH_FROM_1_1_1600) * 100;
             let last_handshake = SystemTime::UNIX_EPOCH + Duration::from_nanos(ns_from_unix_epoch);
 
             let mut wg_peer = WireguardPeer {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -561,11 +561,15 @@ impl Adapter {
                     panic!("Illegal address family {}", address_family);
                 }
             };
-            // The number of 100ns intervals between 1-1-1600 and 1-1-1970
-            const UNIX_EPOCH_FROM_1_1_1600: u64 = 116444736000000000;
-            let ns_from_unix_epoch =
-                peer.LastHandshake.saturating_sub(UNIX_EPOCH_FROM_1_1_1600) * 100;
-            let last_handshake = SystemTime::UNIX_EPOCH + Duration::from_nanos(ns_from_unix_epoch);
+            let last_handshake = if peer.LastHandshake == 0 {
+                None
+            } else {
+                // The number of 100ns intervals between 1-1-1600 and 1-1-1970
+                const UNIX_EPOCH_FROM_1_1_1600: u64 = 116444736000000000;
+                let ns_from_unix_epoch =
+                    peer.LastHandshake.saturating_sub(UNIX_EPOCH_FROM_1_1_1600) * 100;
+                Some(SystemTime::UNIX_EPOCH + Duration::from_nanos(ns_from_unix_epoch))
+            };
 
             let mut wg_peer = WireguardPeer {
                 flags: peer.Flags as u32,
@@ -624,8 +628,8 @@ pub struct WireguardPeer {
     pub tx_bytes: u64,
     /// Number of bytes received
     pub rx_bytes: u64,
-    /// Time of the last handshake
-    pub last_handshake: SystemTime,
+    /// Time of the last handshake, `None` if no handshake has occured
+    pub last_handshake: Option<SystemTime>,
     /// Number of allowed IP structs following this struct
     pub allowed_ips: Vec<IpNet>,
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -9,7 +9,7 @@ use crate::util::{StructReader, UnsafeHandle};
 use crate::wireguard_nt_raw;
 use crate::WireGuardError;
 use std::mem::{align_of, size_of};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::ptr;
@@ -530,12 +530,6 @@ impl Adapter {
             public_key: wireguard_interface.PublicKey,
             peers: Vec::with_capacity(wireguard_interface.PeersCount as usize),
         };
-
-        let now = SystemTime::now();
-        let now_instant = Instant::now();
-        let unix_duration = now
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time set before unix epoch");
 
         for _ in 0..wireguard_interface.PeersCount {
             // # Safety:

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,7 +143,7 @@ impl StructReader {
 
         unsafe { &*ptr.cast::<T>() }
     }
-    
+
     pub fn ptr_mut(&self) -> *mut u8 {
         self.start
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,8 +8,8 @@ use std::{alloc::Layout, sync::Arc};
 /// A wrapper struct that allows a type to be Send and Sync
 pub(crate) struct UnsafeHandle<T>(pub T);
 
-/// We never read from the pointer. It only serves as a handle we pass to the kernel or C code that
-/// doesn't have the same mutable aliasing restrictions we have in Rust
+/// We never read from the pointer. It only serves as a handle we pass to the kernel or C code
+/// (where locks are used internally)
 unsafe impl<T> Send for UnsafeHandle<T> {}
 unsafe impl<T> Sync for UnsafeHandle<T> {}
 
@@ -45,10 +45,11 @@ impl StructWriter {
     /// the next call to [`write`] will return a reference to an adjacent memory location.
     ///
     /// # Safety:
-    /// The caller must ensure the internal pointer is aligned suitably for writing to a T.
+    /// 1. The caller must ensure the internal pointer is aligned suitably for writing to a T.
     /// In most C APIs (like Wireguard NT) the structs are setup in such a way that calling write
     /// repeatedly to pack data into the buffer always yields a struct that is aligned because the
     /// previous struct was aligned.
+    /// 2. The caller must ensure that the zero bit pattern is valid for type T
     ///
     /// # Panics
     /// 1. If writing a struct of size T would overflow the buffer.
@@ -147,6 +148,7 @@ impl StructReader {
     }
 
     /// Returns true if this reader's capacity is full, false otherwise
+    #[allow(dead_code)]
     pub fn is_full(&self) -> bool {
         self.layout.size() == self.offset
     }
@@ -177,7 +179,7 @@ mod tests {
         };
         let mut reader =
             StructReader::new(size_of_val(&expected_data), align_of_val(&expected_data));
-        let byte_buffer: &mut [u8; 8] = unsafe { std::mem::transmute(reader.ptr()) };
+        let byte_buffer: &mut [u8; 8] = unsafe { &mut *(reader.ptr() as *mut [u8; 8]) };
         byte_buffer[0] = 0b10000001;
         byte_buffer[4] = 0x0;
         byte_buffer[5] = 0xFF;


### PR DESCRIPTION
1. Fixes #11 
2. Switches `last_handshake: Instant` to `last_handshake: SystemTime` in `WireguardPeer` to match the underlying C code better
3. Misc documentation improvements