### PR TITLE
Drop rand dependency in favor of getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,12 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies]
-widestring = "0.4"
-log = "0.4"
-rand = "0.8"
 bitflags = "2"
-
-libloading = "0.8"
+getrandom = "0.2.15"
 ipnet = "2.3"
+libloading = "0.8"
+log = "0.4"
+widestring = "0.4"
 windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_Networking",
@@ -32,7 +31,7 @@ windows-sys = { version = "0.52", features = [
 ]}
 
 [dev-dependencies]
-env_logger = "0.11"
 base64 = "0.13"
-x25519-dalek = { version = "2", default-features = false, features = ["static_secrets", "getrandom"] }
+env_logger = "0.11"
 ipnet = "2.3"
+x25519-dalek = { version = "2", default-features = false, features = ["static_secrets", "getrandom"] }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
-use rand::Rng;
 use widestring::U16CString;
 use windows_sys::Win32::{
     Foundation::{GetLastError, ERROR_MORE_DATA, ERROR_OBJECT_ALREADY_EXISTS, ERROR_SUCCESS},
@@ -149,7 +148,7 @@ impl Adapter {
 
         let guid = guid.unwrap_or_else(|| {
             let mut guid_bytes = [0u8; 16];
-            rand::thread_rng().fill(&mut guid_bytes);
+            getrandom::getrandom(&mut guid_bytes).expect("Filed to generate random bytes for guid");
             u128::from_ne_bytes(guid_bytes)
         });
         //SAFETY: guid is a unique integer so transmuting either all zeroes or the user's preferred

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -148,7 +148,7 @@ impl Adapter {
 
         let guid = guid.unwrap_or_else(|| {
             let mut guid_bytes = [0u8; 16];
-            getrandom::getrandom(&mut guid_bytes).expect("Filed to generate random bytes for guid");
+            getrandom::getrandom(&mut guid_bytes).expect("Failed to generate random bytes for guid");
             u128::from_ne_bytes(guid_bytes)
         });
         //SAFETY: guid is a unique integer so transmuting either all zeroes or the user's preferred

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -148,7 +148,8 @@ impl Adapter {
 
         let guid = guid.unwrap_or_else(|| {
             let mut guid_bytes = [0u8; 16];
-            getrandom::getrandom(&mut guid_bytes).expect("Failed to generate random bytes for guid");
+            getrandom::getrandom(&mut guid_bytes)
+                .expect("Failed to generate random bytes for guid");
             u128::from_ne_bytes(guid_bytes)
         });
         //SAFETY: guid is a unique integer so transmuting either all zeroes or the user's preferred


### PR DESCRIPTION
We only use `rand`'s facilities when opening an adapter when the user doesn't specify a GUID. This happens rarely enough that we should just call into `getrandom` instead and save some steps. 