### PR TITLE
Saner error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+
+  semver:
+    name: Check semver
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,14 +45,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
 
-  semver:
-    name: Check semver
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
+# TODO(Troy): re-enable after we bump to fix breaking change in winapi breaking our old compilation
+#  semver:
+#    name: Check semver
+#    runs-on: windows-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: stable
+#          override: true
+#      - uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows
 
 [dependencies]
 bitflags = "2"
-getrandom = "0.2.15"
+getrandom = "0.2"
 ipnet = "2.3"
 libloading = "0.8"
 log = "0.4"
+thiserror = "1.0"
 widestring = "0.4"
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Networking",
     "Win32_Networking_WinSock",

--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -26,11 +26,10 @@ fn main() {
             .expect("Failed to load wireguard dll");
 
     // Try to open an adapter from the given pool with the name "Demo"
-    let adapter =
-        wireguard_nt::Adapter::open(&wireguard, "Demo").unwrap_or_else(|_| {
-            wireguard_nt::Adapter::create(&wireguard, "WireGuard", "Demo", None)
-                .expect("Failed to create wireguard adapter!")
-        });
+    let adapter = wireguard_nt::Adapter::open(&wireguard, "Demo").unwrap_or_else(|_| {
+        wireguard_nt::Adapter::create(&wireguard, "WireGuard", "Demo", None)
+            .expect("Failed to create wireguard adapter!")
+    });
     let mut interface_private = [0; 32];
     let mut peer_pub = [0; 32];
 

--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -64,7 +64,7 @@ fn main() {
         Ok(()) => {}
         Err(err) => panic!("Failed to set default route: {}", err),
     }
-    assert!(adapter.up());
+    assert!(adapter.up().is_ok());
 
     // Go to http://demo.wireguard.com/ and see the bandwidth numbers change!
     println!("Printing peer bandwidth statistics");

--- a/examples/demo_server.rs
+++ b/examples/demo_server.rs
@@ -17,18 +17,18 @@ fn main() {
         get_demo_server_config(public.as_bytes()).expect("Failed to get demo server credentials");
     println!("Connecting to {} - internal ip: {}", endpoint, internal_ip);
 
-    //Must be run as Administrator because we create network adapters
-    //Load the wireguard dll file so that we can call the underlying C functions
-    //Unsafe because we are loading an arbitrary dll file
+    // Must be run as Administrator because we create network adapters
+
+    // Load the wireguard dll file so that we can call the underlying C functions
+    // Unsafe because we are loading an arbitrary dll file
     let wireguard =
         unsafe { wireguard_nt::load_from_path("examples/wireguard_nt/bin/amd64/wireguard.dll") }
             .expect("Failed to load wireguard dll");
 
-    //Try to open an adapter from the given pool with the name "Demo"
+    // Try to open an adapter from the given pool with the name "Demo"
     let adapter =
-        wireguard_nt::Adapter::open(wireguard, "Demo").unwrap_or_else(|(_, wireguard)| {
-            wireguard_nt::Adapter::create(wireguard, "WireGuard", "Demo", None)
-                .map_err(|e| e.0)
+        wireguard_nt::Adapter::open(&wireguard, "Demo").unwrap_or_else(|_| {
+            wireguard_nt::Adapter::create(&wireguard, "WireGuard", "Demo", None)
                 .expect("Failed to create wireguard adapter!")
         });
     let mut interface_private = [0; 32];

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -22,15 +22,14 @@ use windows_sys::Win32::{
     },
 };
 
+use crate::{Error, Result, Wireguard};
 use crate::log::AdapterLoggingLevel;
-use crate::util;
-use crate::util::{StructReader, UnsafeHandle};
+use crate::util::{self, StructReader, UnsafeHandle};
 use crate::wireguard_nt_raw::{
     in6_addr, in_addr, wireguard, GUID, WIREGUARD_ADAPTER_HANDLE, WIREGUARD_ALLOWED_IP,
     WIREGUARD_INTERFACE, WIREGUARD_INTERFACE_FLAG, WIREGUARD_PEER, WIREGUARD_PEER_FLAG,
     _NET_LUID_LH,
 };
-use crate::WireGuardError;
 
 /// Representation of a wireGuard adapter with safe idiomatic bindings to the functionality provided by
 /// the WireGuard* C functions.
@@ -89,12 +88,8 @@ pub struct SetInterface {
 
 fn encode_name(
     name: &str,
-    wireguard: Arc<wireguard>,
-) -> Result<(U16CString, Arc<wireguard>), (WireGuardError, Arc<wireguard>)> {
-    let utf16 = match U16CString::from_str(name) {
-        Ok(u) => u,
-        Err(e) => return Err((e.into(), wireguard)),
-    };
+) -> Result<U16CString> {
+    let utf16 = U16CString::from_str(name)?;
     let max = crate::MAX_NAME;
     if utf16.len() >= max {
         //max_characters is the maximum number of characters including the null terminator. And .len() measures the
@@ -102,18 +97,9 @@ fn encode_name(
         //max_characters - 1 because the null terminator sits in the last element. A string
         //of length max_characters needs max_characters + 1 to store the null terminator so the >=
         //check holds
-        Err((
-            format!(
-                //TODO: Better error handling
-                "Length too large. Size: {}, Max: {}",
-                utf16.len(),
-                max,
-            )
-            .into(),
-            wireguard,
-        ))
+        Err(Error::NameTooLarge)
     } else {
-        Ok((utf16, wireguard))
+        Ok(utf16)
     }
 }
 
@@ -123,9 +109,9 @@ pub struct EnumeratedAdapter {
     pub name: String,
 }
 
-fn win_error(context: &str, error_code: u32) -> Result<(), Box<dyn std::error::Error>> {
+fn win_error(context: &str, error_code: u32) -> Result<()> {
     let e = std::io::Error::from_raw_os_error(error_code as i32);
-    Err(format!("{} - {}", context, e).into())
+    Err(Error::Windows(context.to_string(), e))
 }
 
 const WIREGUARD_STATE_DOWN: i32 = 0;
@@ -138,13 +124,13 @@ impl Adapter {
     ///
     /// Optionally a GUID can be specified that will become the GUID of this adapter once created.
     pub fn create(
-        wireguard: Arc<wireguard>,
+        wireguard: &Wireguard,
         pool: &str,
         name: &str,
         guid: Option<u128>,
-    ) -> Result<Adapter, (WireGuardError, Arc<wireguard>)> {
-        let (pool_utf16, wireguard) = encode_name(pool, wireguard)?;
-        let (name_utf16, wireguard) = encode_name(name, wireguard)?;
+    ) -> Result<Adapter> {
+        let pool_utf16 = encode_name(pool)?;
+        let name_utf16 = encode_name(name)?;
 
         let guid = guid.unwrap_or_else(|| {
             let mut guid_bytes = [0u8; 16];
@@ -159,7 +145,7 @@ impl Adapter {
         //the byte order of the segments of the GUID struct that are larger than a byte. Verify
         //that this works as expected
 
-        crate::log::set_default_logger_if_unset(&wireguard);
+        crate::log::set_default_logger_if_unset(wireguard);
 
         //SAFETY: the function is loaded from the wireguard dll properly, we are providing valid
         //pointers, and all the strings are correct null terminated UTF-16. This safety rationale
@@ -173,38 +159,38 @@ impl Adapter {
         };
 
         if result.is_null() {
-            Err(("Failed to create adapter".into(), wireguard))
+            Err(Error::Driver(std::io::Error::last_os_error()))
         } else {
             Ok(Self {
                 adapter: UnsafeHandle(result),
-                wireguard,
+                wireguard: Arc::clone(&wireguard.0),
             })
         }
     }
 
     /// Attempts to open an existing wireguard with name `name`.
     pub fn open(
-        wireguard: Arc<wireguard>,
+        wireguard: &Wireguard,
         name: &str,
-    ) -> Result<Adapter, (WireGuardError, Arc<wireguard>)> {
-        let (name_utf16, wireguard) = encode_name(name, wireguard)?;
+    ) -> Result<Adapter> {
+        let name_utf16 = encode_name(name)?;
 
-        crate::log::set_default_logger_if_unset(&wireguard);
+        crate::log::set_default_logger_if_unset(wireguard);
 
         let result = unsafe { wireguard.WireGuardOpenAdapter(name_utf16.as_ptr()) };
 
         if result.is_null() {
-            Err(("WireGuardOpenAdapter failed".into(), wireguard))
+            Err(Error::Driver(std::io::Error::last_os_error()))
         } else {
             Ok(Adapter {
                 adapter: UnsafeHandle(result),
-                wireguard,
+                wireguard: Arc::clone(&wireguard.0),
             })
         }
     }
 
     /// Sets the wireguard configuration of this adapter
-    pub fn set_config(&self, config: &SetInterface) -> Result<(), WireGuardError> {
+    pub fn set_config(&self, config: &SetInterface) -> Result<()> {
         bitflags::bitflags! {
             struct InterfaceFlags: i32 {
                 const HAS_PUBLIC_KEY =  1 << 0;
@@ -345,7 +331,7 @@ impl Adapter {
         };
 
         match result {
-            0 => Err("WireGuardSetConfiguration failed".into()),
+            0 => Err(Error::Driver(std::io::Error::last_os_error())),
             _ => Ok(()),
         }
     }
@@ -356,7 +342,7 @@ impl Adapter {
         &self,
         interface_addrs: &[IpNet],
         config: &SetInterface,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<()> {
         let luid = self.get_luid();
         unsafe {
             for allowed_ip in config.peers.iter().flat_map(|p| p.allowed_ips.iter()) {
@@ -390,7 +376,7 @@ impl Adapter {
 
                 let err = CreateIpForwardEntry2(&default_route);
                 if err != ERROR_SUCCESS && err != ERROR_OBJECT_ALREADY_EXISTS {
-                    return win_error("Failed to set default route", err);
+                    return win_error("CreateIpForwardEntry2", err);
                 }
             }
 
@@ -427,13 +413,13 @@ impl Adapter {
 
                 let err = CreateUnicastIpAddressEntry(&address_row);
                 if err != ERROR_SUCCESS && err != ERROR_OBJECT_ALREADY_EXISTS {
-                    return win_error("Failed to set IP interface", err);
+                    return win_error("CreateUnicastIpAddressEntry", err);
                 }
             }
 
             let err = GetIpInterfaceEntry(&mut ip_interface);
             if err != ERROR_SUCCESS {
-                return win_error("Failed to get IP interface", err);
+                return win_error("GetIpInterfaceEntry", err);
             }
             ip_interface.UseAutomaticMetric = 0;
             ip_interface.Metric = 0;
@@ -441,7 +427,7 @@ impl Adapter {
             ip_interface.SitePrefixLength = 0;
             let err = SetIpInterfaceEntry(&mut ip_interface);
             if err != ERROR_SUCCESS {
-                return win_error("Failed to set metric and MTU", err);
+                return win_error("SetIpInterfaceEntry", err);
             }
 
             Ok(())
@@ -449,7 +435,7 @@ impl Adapter {
     }
 
     /// Get the state of this adapter
-    pub fn is_up(&self) -> Result<bool, std::io::Error> {
+    pub fn is_up(&self) -> Result<bool> {
         let mut state = 0;
         let success = unsafe {
             self.wireguard
@@ -459,12 +445,12 @@ impl Adapter {
         if success {
             Ok(state == WIREGUARD_STATE_UP)
         } else {
-            Err(std::io::Error::last_os_error())
+            Err(Error::Driver(std::io::Error::last_os_error()))
         }
     }
 
     /// Puts this adapter into the up state
-    pub fn up(&self) -> Result<(), std::io::Error> {
+    pub fn up(&self) -> Result<()> {
         let success = unsafe {
             self.wireguard
                 .WireGuardSetAdapterState(self.adapter.0, WIREGUARD_STATE_UP)
@@ -473,12 +459,12 @@ impl Adapter {
         if success {
             Ok(())
         } else {
-            Err(std::io::Error::last_os_error())
+            Err(Error::Driver(std::io::Error::last_os_error()))
         }
     }
 
     /// Puts this adapter into the down state
-    pub fn down(&self) -> Result<(), std::io::Error> {
+    pub fn down(&self) -> Result<()> {
         let success = unsafe {
             self.wireguard
                 .WireGuardSetAdapterState(self.adapter.0, WIREGUARD_STATE_DOWN)
@@ -487,7 +473,7 @@ impl Adapter {
         if success {
             Ok(())
         } else {
-            Err(std::io::Error::last_os_error())
+            Err(Error::Driver(std::io::Error::last_os_error()))
         }
     }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -22,7 +22,6 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::{Error, Result, Wireguard};
 use crate::log::AdapterLoggingLevel;
 use crate::util::{self, StructReader, UnsafeHandle};
 use crate::wireguard_nt_raw::{
@@ -30,6 +29,7 @@ use crate::wireguard_nt_raw::{
     WIREGUARD_INTERFACE, WIREGUARD_INTERFACE_FLAG, WIREGUARD_PEER, WIREGUARD_PEER_FLAG,
     _NET_LUID_LH,
 };
+use crate::{Error, Result, Wireguard};
 
 /// Representation of a wireGuard adapter with safe idiomatic bindings to the functionality provided by
 /// the WireGuard* C functions.
@@ -86,9 +86,7 @@ pub struct SetInterface {
     pub peers: Vec<SetPeer>,
 }
 
-fn encode_name(
-    name: &str,
-) -> Result<U16CString> {
+fn encode_name(name: &str) -> Result<U16CString> {
     let utf16 = U16CString::from_str(name)?;
     let max = crate::MAX_NAME;
     if utf16.len() >= max {
@@ -169,10 +167,7 @@ impl Adapter {
     }
 
     /// Attempts to open an existing wireguard with name `name`.
-    pub fn open(
-        wireguard: &Wireguard,
-        name: &str,
-    ) -> Result<Adapter> {
+    pub fn open(wireguard: &Wireguard, name: &str) -> Result<Adapter> {
         let name_utf16 = encode_name(name)?;
 
         crate::log::set_default_logger_if_unset(wireguard);

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -453,7 +453,8 @@ impl Adapter {
         let mut state = 0;
         let success = unsafe {
             self.wireguard
-                .WireGuardGetAdapterState(self.adapter.0, &mut state ) != 0
+                .WireGuardGetAdapterState(self.adapter.0, &mut state)
+                != 0
         };
         if success {
             Ok(state == WIREGUARD_STATE_UP)

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -448,21 +448,45 @@ impl Adapter {
         }
     }
 
+    /// Get the state of this adapter
+    pub fn is_up(&self) -> Result<bool, std::io::Error> {
+        let mut state = 0;
+        let success = unsafe {
+            self.wireguard
+                .WireGuardGetAdapterState(self.adapter.0, &mut state ) != 0
+        };
+        if success {
+            Ok(state == WIREGUARD_STATE_UP)
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
     /// Puts this adapter into the up state
-    pub fn up(&self) -> bool {
-        unsafe {
+    pub fn up(&self) -> Result<(), std::io::Error> {
+        let success = unsafe {
             self.wireguard
                 .WireGuardSetAdapterState(self.adapter.0, WIREGUARD_STATE_UP)
                 != 0
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
         }
     }
 
     /// Puts this adapter into the down state
-    pub fn down(&self) -> bool {
-        unsafe {
+    pub fn down(&self) -> Result<(), std::io::Error> {
+        let success = unsafe {
             self.wireguard
                 .WireGuardSetAdapterState(self.adapter.0, WIREGUARD_STATE_DOWN)
                 != 0
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! # Example
 //! ```no_run
 //! // Must be run as Administrator because we create network adapters
-//! 
+//!
 //! // Load the wireguard dll file so that we can call the underlying C functions
 //! // Unsafe because we are loading an arbitrary dll file
 //! let wireguard =
@@ -99,8 +99,8 @@ pub use crate::adapter::*;
 pub use crate::log::*;
 pub use crate::util::get_running_driver_version;
 
-pub use wireguard_nt_raw::wireguard as Sys;
 use std::sync::Arc;
+pub use wireguard_nt_raw::wireguard as Sys;
 
 use thiserror::Error;
 
@@ -111,7 +111,7 @@ pub enum Error {
     Driver(#[from] std::io::Error),
     /// Unable to encode UTF-16 string due to early null
     #[error("invalid string: {0}")]
-    Null(#[from] widestring::NulError::<u16>),
+    Null(#[from] widestring::NulError<u16>),
     #[error("name too large (max {})", crate::MAX_NAME)]
     NameTooLarge,
     /// The windows function (self.0), failed with the given error (self.1)
@@ -188,9 +188,9 @@ pub unsafe fn load_from_library<L>(library: L) -> std::result::Result<Wireguard,
 where
     L: Into<libloading::Library>,
 {
-    Ok(Wireguard(Arc::new(wireguard_nt_raw::wireguard::from_library(
-        library,
-    )?)))
+    Ok(Wireguard(Arc::new(
+        wireguard_nt_raw::wireguard::from_library(library)?,
+    )))
 }
 
 // The error type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,21 +19,20 @@
 //!
 //! # Example
 //! ```no_run
-//! //Must be run as Administrator because we create network adapters
-//! //Load the wireguard dll file so that we can call the underlying C functions
-//! //Unsafe because we are loading an arbitrary dll file
-//! let wireguard = unsafe { wireguard_nt::load_from_path("path/to/wireguard.dll") }.expect("Failed to load wireguard dll");
-//! //Try to open an adapter with the name "Demo"
-//! let adapter = match wireguard_nt::Adapter::open(wireguard, "Demo") {
-//!     Ok(a) => a,
-//!     Err((_, wireguard)) => {
-//!         //If loading failed (most likely it didn't exist), create a new one
-//!         match wireguard_nt::Adapter::create(wireguard, "WireGuard", "Demo", None) {
-//!             Ok(a) => a,
-//!             Err((e, _)) => panic!("Failed to create adapter: {:?}", e),
-//!         }
-//!     }
-//! };
+//! // Must be run as Administrator because we create network adapters
+//! 
+//! // Load the wireguard dll file so that we can call the underlying C functions
+//! // Unsafe because we are loading an arbitrary dll file
+//! let wireguard =
+//!     unsafe { wireguard_nt::load_from_path("examples/wireguard_nt/bin/amd64/wireguard.dll") }
+//!         .expect("Failed to load wireguard dll");
+//!
+//! // Try to open an adapter from the given pool with the name "Demo"
+//! let adapter =
+//!     wireguard_nt::Adapter::open(&wireguard, "Demo").unwrap_or_else(|_| {
+//!         wireguard_nt::Adapter::create(&wireguard, "WireGuard", "Demo", None)
+//!             .expect("Failed to create wireguard adapter!")
+//!     });
 //!
 //! let interface = wireguard_nt::SetInterface {
 //!     //Let the OS pick a port for us
@@ -100,9 +99,43 @@ pub use crate::adapter::*;
 pub use crate::log::*;
 pub use crate::util::get_running_driver_version;
 
-pub use wireguard_nt_raw::wireguard as dll;
-
+pub use wireguard_nt_raw::wireguard as Sys;
 use std::sync::Arc;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    /// An error caused by calling into the wireguard-nt driver
+    #[error("{0}")]
+    Driver(#[from] std::io::Error),
+    /// Unable to encode UTF-16 string due to early null
+    #[error("invalid string: {0}")]
+    Null(#[from] widestring::NulError::<u16>),
+    #[error("name too large (max {})", crate::MAX_NAME)]
+    NameTooLarge,
+    /// The windows function (self.0), failed with the given error (self.1)
+    #[error("{0}: {1}")]
+    Windows(String, std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Clone)]
+pub struct Wireguard(Arc<Sys>);
+
+impl Wireguard {
+    pub fn into_inner(self) -> Arc<Sys> {
+        self.0
+    }
+}
+
+impl std::ops::Deref for Wireguard {
+    type Target = Sys;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Attempts to load the Wireguand NT library from the current directory using the default name "wireguard.dll".
 ///
@@ -118,7 +151,7 @@ use std::sync::Arc;
 /// Hoverer one can never be too cautious when loading a dll file.
 ///
 /// For more information see [`libloading`]'s dynamic library safety guarantees: [`libloading`][`libloading::Library::new`]
-pub unsafe fn load() -> Result<Arc<dll>, libloading::Error> {
+pub unsafe fn load() -> std::result::Result<Wireguard, libloading::Error> {
     load_from_path("wireguard")
 }
 
@@ -134,11 +167,11 @@ pub unsafe fn load() -> Result<Arc<dll>, libloading::Error> {
 /// Hoverer one can never be too cautious when loading a dll file.
 ///
 /// For more information see [`libloading`]'s dynamic library safety guarantees: [`libloading`][`libloading::Library::new`]
-pub unsafe fn load_from_path<P>(path: P) -> Result<Arc<dll>, libloading::Error>
+pub unsafe fn load_from_path<P>(path: P) -> std::result::Result<Wireguard, libloading::Error>
 where
     P: AsRef<::std::ffi::OsStr>,
 {
-    Ok(Arc::new(wireguard_nt_raw::wireguard::new(path)?))
+    Ok(Wireguard(Arc::new(wireguard_nt_raw::wireguard::new(path)?)))
 }
 
 /// Attempts to load the WireGuard NT library from an existing [`libloading::Library`].
@@ -151,14 +184,14 @@ where
 /// is inherently unsafe.
 ///
 /// For more information see [`libloading`]'s dynamic library safety guarantees: [`libloading::Library::new`]
-pub unsafe fn load_from_library<L>(library: L) -> Result<Arc<dll>, libloading::Error>
+pub unsafe fn load_from_library<L>(library: L) -> std::result::Result<Wireguard, libloading::Error>
 where
     L: Into<libloading::Library>,
 {
-    Ok(Arc::new(wireguard_nt_raw::wireguard::from_library(
+    Ok(Wireguard(Arc::new(wireguard_nt_raw::wireguard::from_library(
         library,
-    )?))
+    )?)))
 }
 
-/// The error type
-pub type WireGuardError = Box<dyn std::error::Error>;
+// The error type
+// pub type WireGuardError = Box<dyn std::error::Error>;

--- a/src/log.rs
+++ b/src/log.rs
@@ -5,10 +5,7 @@ use widestring::U16CStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Sets the logger wireguard will use when logging. Maps to the wireguardSetLogger C function
-pub fn set_logger(
-    wireguard: &crate::Wireguard,
-    f: wireguard_nt_raw::WIREGUARD_LOGGER_CALLBACK,
-) {
+pub fn set_logger(wireguard: &crate::Wireguard, f: wireguard_nt_raw::WIREGUARD_LOGGER_CALLBACK) {
     unsafe { wireguard.WireGuardSetLogger(f) };
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -3,11 +3,10 @@ use log::*;
 use widestring::U16CStr;
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 
 /// Sets the logger wireguard will use when logging. Maps to the wireguardSetLogger C function
 pub fn set_logger(
-    wireguard: &Arc<wireguard_nt_raw::wireguard>,
+    wireguard: &crate::Wireguard,
     f: wireguard_nt_raw::WIREGUARD_LOGGER_CALLBACK,
 ) {
     unsafe { wireguard.WireGuardSetLogger(f) };
@@ -54,7 +53,7 @@ pub extern "C" fn default_logger(
     }
 }
 
-pub(crate) fn set_default_logger_if_unset(wireguard: &Arc<wireguard_nt_raw::wireguard>) {
+pub(crate) fn set_default_logger_if_unset(wireguard: &crate::Wireguard) {
     if !SET_LOGGER.load(Ordering::Relaxed) {
         set_logger(wireguard, Some(default_logger));
         SET_LOGGER.store(true, Ordering::Relaxed);


### PR DESCRIPTION
* Adds new error type powered by `thiserror` to remove `Box<dyn std::error::Error>` cruft
* Misc documentation improvements
* Adds `Wireguard` newtype wrapper around raw bindgen struct
* Bumps `windows-sys` to 0.59